### PR TITLE
Fix for some time string formatting errors

### DIFF
--- a/restic-exporter.py
+++ b/restic-exporter.py
@@ -97,7 +97,7 @@ class ResticCollector(object):
         for snap in latest_snapshots:
             stats = self.get_stats(snap['id'])
 
-            time_parsed = re.sub(r'\.[^+-]+', '', snap['time'])
+            time_parsed = re.sub(r'\.[0-9]+', '', snap['time'])
             timestamp = time.mktime(datetime.datetime.strptime(time_parsed, "%Y-%m-%dT%H:%M:%S%z").timetuple())
 
             snapshots_total = 0


### PR DESCRIPTION
In case of UTC time string given in the following format: '2023-02-01T14:14:19.30760523Z', the current regexp fails.

It is enough to remove the milliseconds by targeting them directly instead of removing all the characters after the first period('.') found in string.

fixes #1