### PR TITLE
Use empty username when username is not present in snapshot.

### DIFF
--- a/restic-exporter.py
+++ b/restic-exporter.py
@@ -117,7 +117,7 @@ class ResticCollector(object):
             clients.append({
                 'snapshot_hash': snap['hash'],
                 'hostname': snap['hostname'],
-                'username': snap['username'],
+                'username': snap['username'] if 'username' in snap else '',
                 'timestamp': timestamp,
                 'size_total': stats['total_size'],
                 'files_total': stats['total_file_count'],


### PR DESCRIPTION
This MR is fixing a crash when the snapshot has no username field in JSON. The missing username is replaced with a space.

(I have snapshots of my smartphone where the `username` key is missing)