### PR TITLE
Support exporting multiple tags not just the first one

### DIFF
--- a/restic-exporter.py
+++ b/restic-exporter.py
@@ -183,7 +183,7 @@ class ResticCollector(object):
                     "username": snap["username"],
                     "version": snap["program_version"] if "program_version" in snap else "",
                     "snapshot_hash": snap["hash"],
-                    "snapshot_tag": snap["tags"][0] if "tags" in snap else "",
+                    "snapshot_tag": ",".join(snap["tags"]) if "tags" in snap else "",
                     "snapshot_paths": ",".join(snap["paths"]) if self.include_paths else "",
                     "timestamp": snap["timestamp"],
                     "size_total": stats["total_size"],


### PR DESCRIPTION
This will join the various tags together in the exporter not just the first one in the array. 
I have verified that this won't break the Grafana dashboards, that it will easily display the multiple tags.