### PR TITLE
fix: wrong lock count, header output changed in restic versions

### DIFF
--- a/restic-exporter.py
+++ b/restic-exporter.py
@@ -325,7 +325,6 @@ class ResticCollector(object):
         for line in text_result.split("\n"):
             if re.match("^[a-z0-9]+$", line):
                 lock_counter += 1
-        logging.info(f"Found {lock_counter} locks in repository.")
 
         return lock_counter
 

--- a/restic-exporter.py
+++ b/restic-exporter.py
@@ -321,7 +321,13 @@ class ResticCollector(object):
                 "Error executing restic list locks command: " + self.parse_stderr(result)
             )
         text_result = result.stdout.decode("utf-8")
-        return len(text_result.split("\n")) - 1
+        lock_counter = 0
+        for line in text_result.split("\n"):
+            if re.match("^[a-z0-9]+$", line):
+                lock_counter += 1
+        logging.info(f"Found {lock_counter} locks in repository.")
+
+        return lock_counter
 
     @staticmethod
     def calc_snapshot_hash(snapshot: dict) -> str:


### PR DESCRIPTION
Hey,

I noticed that the metric for the locks was not behaving correctly anymore.

This is due to restic not outputting the header:
```
repository xyz opened successfully, password is correct
```
anymore if the output is redirected.
You can test that locally with `restic list locks --no-locks > test.log`.

My solution is to just split the lines by linebreaks and see if the resulting string looks like an ID by a regex -> increasing the counter by one.