### PR TITLE
Add INSECURE_TLS env var to skip TLS verification for self-signed certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## next_release
+
+* Added INSECURE_TLS env var - now is possible to skip TLS verification for self-signed certificates
+
 ## 1.5.0 (2024/01/20)
 
 * Replaced RESTIC_REPO_URL, RESTIC_REPO_PASSWORD and RESTIC_REPO_PASSWORD_FILE environment variables with the Restic equivalents

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ reasons. Default is `False` (perform `restic check`).
 reasons. Default is `False` (collect per backup statistics).
 - `NO_LOCKS`: (Optional) Do not collect the number of locks. Default is `False` (collect the number of locks).
 - `INCLUDE_PATHS`: (Optional) Include snapshot paths for each backup. The paths are separated by commas. Default is `False` (not collect the paths).
+- `INSECURE_TLS`: (Optional) skip TLS verification for self-signed certificates. Default is `False` (not skip).
 
 ### Configuration for Rclone
 

--- a/restic-exporter.py
+++ b/restic-exporter.py
@@ -17,7 +17,7 @@ from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily, REGIS
 class ResticCollector(object):
     def __init__(
         self, repository, password_file, exit_on_error, disable_check,
-            disable_stats, disable_locks, include_paths
+            disable_stats, disable_locks, include_paths, insecure_tls
     ):
         self.repository = repository
         self.password_file = password_file
@@ -26,6 +26,7 @@ class ResticCollector(object):
         self.disable_stats = disable_stats
         self.disable_locks = disable_locks
         self.include_paths = include_paths
+        self.insecure_tls = insecure_tls
         # todo: the stats cache increases over time -> remove old ids
         # todo: cold start -> the stats cache could be saved in a persistent volume
         # todo: cold start -> the restic cache (/root/.cache/restic) could be
@@ -238,6 +239,9 @@ class ResticCollector(object):
         if only_latest:
             cmd.extend(["--latest", "1"])
 
+        if self.insecure_tls:
+            cmd.extend(["--insecure-tls"])
+
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode != 0:
             raise Exception(
@@ -270,6 +274,9 @@ class ResticCollector(object):
         if snapshot_id is not None:
             cmd.extend([snapshot_id])
 
+        if self.insecure_tls:
+            cmd.extend(["--insecure-tls"])
+
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode != 0:
             raise Exception(
@@ -294,6 +301,9 @@ class ResticCollector(object):
             "check",
         ]
 
+        if self.insecure_tls:
+            cmd.extend(["--insecure-tls"])
+
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode == 0:
             return 1  # ok
@@ -314,6 +324,9 @@ class ResticCollector(object):
             "list",
             "locks",
         ]
+
+        if self.insecure_tls:
+            cmd.extend(["--insecure-tls"])
 
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if result.returncode != 0:
@@ -379,6 +392,7 @@ if __name__ == "__main__":
     exporter_disable_stats = bool(os.environ.get("NO_STATS", False))
     exporter_disable_locks = bool(os.environ.get("NO_LOCKS", False))
     exporter_include_paths = bool(os.environ.get("INCLUDE_PATHS", False))
+    exporter_insecure_tls = bool(os.environ.get("INSECURE_TLS", False))
 
     try:
         collector = ResticCollector(
@@ -389,6 +403,7 @@ if __name__ == "__main__":
             exporter_disable_stats,
             exporter_disable_locks,
             exporter_include_paths,
+            exporter_insecure_tls,
         )
         REGISTRY.register(collector)
         start_http_server(exporter_port, exporter_address)


### PR DESCRIPTION
According to Restic documents, we can skip TLS certificate verification when connecting to the repository (insecure)
I only Added `INSECURE_TLS` env var to skip TLS verification for self-signed certificates