### PR TITLE
Fix crash when collect() is called before metrics are ready

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -102,6 +102,10 @@ class ResticCollector(Collector):
     def collect(self) -> Iterable[Metric]:
         logging.debug("Incoming request")
 
+        # If metrics haven't been collected yet, return empty
+        if self.metrics is None:
+            return
+
         common_label_names: list[str] = [
             "client_hostname",
             "client_username",

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -177,6 +177,14 @@ class TestResticCollector:
         assert "restic_backup_data_added_bytes" in metric_names
         assert "restic_backup_duration_seconds" in metric_names
 
+    def test_collect_metrics_when_none(self, restic_collector):
+        """Test the collect method returns empty when metrics are None"""
+        # Don't call refresh, so metrics stays None
+        assert restic_collector.metrics is None
+        metrics = list(restic_collector.collect())
+        # Should return empty list without crashing
+        assert len(metrics) == 0
+
     def test_get_metrics_disabled_features(self, restic_collector, mock_restic_cli):
         restic_collector.disable_check = True
         restic_collector.disable_global_stats = True


### PR DESCRIPTION
In my setup, restic repositories may be unavailable at container startup/restart. I would expect the variable `EXIT_ON_ERROR=False` to also work at container startup, when no successful metrics were ever pulled before, so that the container can check every refresh cycle again for a working repository.

Right now, it fails, because the self.metrics are not populated yet:
```
2026-01-26 14:35:17 ERROR    Unable to collect metrics from Restic. Exception: Error executing restic snapshot command: {"message_type":"exit_error","code":10,"message":"Fatal: repository does not exist: unable to open config file: stat data/config: no such file or directory\nIs there a repository at the following location?\n./data"}  Exit code: 10
Traceback (most recent call last):
  File "/Users/robin/Development/repos/restic-exporter/exporter/exporter.py", line 622, in <module>
    main()
  File "/Users/robin/Development/repos/restic-exporter/exporter/exporter.py", line 607, in main
    REGISTRY.register(collector)
  File "/Users/robin/Development/repos/restic-exporter/.venv/lib/python3.12/site-packages/prometheus_client/registry.py", line 40, in register
    names = self._get_names(collector)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/robin/Development/repos/restic-exporter/.venv/lib/python3.12/site-packages/prometheus_client/registry.py", line 80, in _get_names
    for metric in desc_func():
                  ^^^^^^^^^^^
  File "/Users/robin/Development/repos/restic-exporter/exporter/exporter.py", line 218, in collect
    check_success.add_metric([], self.metrics.check_success)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'check_success'
```

This PR attempts to fix the problem. Now it returns empty metrics gracefully, allowing the exporter to start and populate metrics once the repository becomes available. I also added a test to verify behavior.

Would this be an acceptable solution?