### PR TITLE
add proper handling of boolean environemnt variables

### DIFF
--- a/exporter/exporter.py
+++ b/exporter/exporter.py
@@ -553,6 +553,20 @@ def get_version() -> str:
     return "unknown"
 
 
+def parse_bool_env(env_var_name: str, default: bool = False) -> bool:
+    value = os.environ.get(env_var_name)
+
+    if value is None:
+        return default
+
+    # Explicit false values should return False
+    if value.strip().lower() in ("false", "0", ""):
+        return False
+
+    # Any other set string returns True
+    return True
+
+
 def main(refresh_loop: bool = True) -> None:
     logging.basicConfig(
         format="%(asctime)s %(levelname)-8s %(message)s",
@@ -586,13 +600,13 @@ def main(refresh_loop: bool = True) -> None:
     exporter_address = os.environ.get("LISTEN_ADDRESS", "0.0.0.0")
     exporter_port = int(os.environ.get("LISTEN_PORT", 8001))
     exporter_refresh_interval = int(os.environ.get("REFRESH_INTERVAL", 3600))
-    exporter_exit_on_error = bool(os.environ.get("EXIT_ON_ERROR", False))
-    exporter_disable_check = bool(os.environ.get("NO_CHECK", False))
-    exporter_disable_global_stats = bool(os.environ.get("NO_GLOBAL_STATS", False))
-    exporter_disable_legacy_stats = bool(os.environ.get("NO_LEGACY_STATS", False))
-    exporter_disable_locks = bool(os.environ.get("NO_LOCKS", False))
-    exporter_include_paths = bool(os.environ.get("INCLUDE_PATHS", False))
-    exporter_insecure_tls = bool(os.environ.get("INSECURE_TLS", False))
+    exporter_exit_on_error = parse_bool_env("EXIT_ON_ERROR", False)
+    exporter_disable_check = parse_bool_env("NO_CHECK", False)
+    exporter_disable_global_stats = parse_bool_env("NO_GLOBAL_STATS", False)
+    exporter_disable_legacy_stats = parse_bool_env("NO_LEGACY_STATS", False)
+    exporter_disable_locks = parse_bool_env("NO_LOCKS", False)
+    exporter_include_paths = parse_bool_env("INCLUDE_PATHS", False)
+    exporter_insecure_tls = parse_bool_env("INSECURE_TLS", False)
 
     try:
         collector = ResticCollector(

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -704,6 +704,60 @@ class TestResticCollector:
         assert result == "Error: repository not found  Exit code: 1"
 
 
+class TestParseBoolEnv:
+    """Test the parse_bool_env() helper function for boolean environment variable parsing"""
+
+    def test_false_values_false_string(self):
+        """Test that 'false' string correctly parses as False"""
+        with patch.dict(os.environ, {"TEST_VAR": "false"}):
+            assert parse_bool_env("TEST_VAR") is False
+
+    def test_false_values_false_uppercase(self):
+        """Test that 'False' string correctly parses as False"""
+        with patch.dict(os.environ, {"TEST_VAR": "False"}):
+            assert parse_bool_env("TEST_VAR") is False
+
+    def test_false_values_zero_string(self):
+        """Test that '0' string correctly parses as False"""
+        with patch.dict(os.environ, {"TEST_VAR": "0"}):
+            assert parse_bool_env("TEST_VAR") is False
+
+    def test_false_values_empty_string(self):
+        """Test that empty string correctly parses as False"""
+        with patch.dict(os.environ, {"TEST_VAR": ""}):
+            assert parse_bool_env("TEST_VAR") is False
+
+    def test_true_values_true_string(self):
+        """Test that 'true' string correctly parses as True"""
+        with patch.dict(os.environ, {"TEST_VAR": "true"}):
+            assert parse_bool_env("TEST_VAR") is True
+
+    def test_true_values_true_uppercase(self):
+        """Test that 'True' string correctly parses as True"""
+        with patch.dict(os.environ, {"TEST_VAR": "True"}):
+            assert parse_bool_env("TEST_VAR") is True
+
+    def test_true_values_one_string(self):
+        """Test that '1' string correctly parses as True"""
+        with patch.dict(os.environ, {"TEST_VAR": "1"}):
+            assert parse_bool_env("TEST_VAR") is True
+
+    def test_true_values_arbitrary_string(self):
+        """Test that arbitrary non-empty strings parse as True (lenient behavior)"""
+        with patch.dict(os.environ, {"TEST_VAR": "anything"}):
+            assert parse_bool_env("TEST_VAR") is True
+
+    def test_default_false_when_unset(self):
+        """Test that unset variable returns default False"""
+        with patch.dict(os.environ, {}, clear=True):
+            assert parse_bool_env("NONEXISTENT_VAR", False) is False
+
+    def test_default_true_when_unset(self):
+        """Test that unset variable returns default True"""
+        with patch.dict(os.environ, {}, clear=True):
+            assert parse_bool_env("NONEXISTENT_VAR", True) is True
+
+
 class TestMain:
     @patch("exporter.exporter.start_http_server")
     @patch("exporter.exporter.REGISTRY.register")


### PR DESCRIPTION
When defining environment variables in docker-compose.yml, writing explicit `False` values should parse the value correctly.

Right now, if I set `False` values like these:

```yaml
environment:
  - EXIT_ON_ERROR=False
  - NO_CHECK=False

# or like this:
environment:
  EXIT_ON_ERROR: "False"
  NO_CHECK: "False"
  ```
 
 python interprets them as `True` because of the `bool()` wrapper in `bool(os.environ.get(...))`, causing the opposite behavior from what the user intended.

This PR attemts to fix it by adding a proper parse_bool_env() helper function that correctly handles bool environment variables. To minimize impact, it only handles explicitly (case-insensitive) set  `False`, `0`, or an empty string, defaulting to `True` if any other string is set. When no environment variable is set, it defaults to the default value as before.

I added some unit tests to validate the behaviour. 