### PR TITLE
Fix stacked rendering of the total backup size panel in grafana dashboard

### DIFF
--- a/grafana/grafana_dashboard.json
+++ b/grafana/grafana_dashboard.json
@@ -971,7 +971,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "normal"
+              "mode": "none"
             },
             "thresholdsStyle": {
               "mode": "off"


### PR DESCRIPTION
The "Total backup size" graph had stacking enabled, causing visual artifacts where changes in one host's backup size affected the rendering of all other hosts above it. Values were correct, rendering was broken.

Changed stacking mode from "normal" to "none". Each host now renders independently.


## Before

<img width="951" height="355" alt="image" src="https://github.com/user-attachments/assets/16b68ee2-3188-4af1-b285-ad26772e844b" />


## After

<img width="939" height="345" alt="image" src="https://github.com/user-attachments/assets/3e8d0a9c-74e7-492b-a85e-e83819bd57bf" />
